### PR TITLE
Add a snap package (https://snapcraft.io)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "dmg": {
       "icon": "resources/osx/dmg-icon.icns",
       "background": "resources/osx/dmg-background.png"
+    },
+    "linux": {
+      "target": "snap"
     }
   },
   "directories": {
@@ -35,7 +38,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "electron": "1.3.3",
-    "electron-builder": "^5.12.1",
+    "electron-builder": "^19.50.0",
     "electron-mocha": "^3.0.0",
     "fs-jetpack": "^0.9.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 17.10 and 16.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run release` it will create `dist/ling_0.2.0_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous ling_0.2.0_amd64.snap`

Run with `ling` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "ling" name](https://dashboard.snapcraft.io/register-snap/?name=ling).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push Ling out with:
`snapcraft push ling_0.2.0_amd64.snap --release stable`

  
  
  